### PR TITLE
Android: strip leading RRULE: prefix when writing recurrence  rule (fixes Invalid recurrence rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.5
+
+### Bug Fixes
+- Fixed recurring-event creation validation for RRULE strings (e.g. `RRULE:FREQ=DAILY;COUNT=10`) that previously caused "Invalid recurrence rule" errors when calling `createEvent`. Thanks to @jaydaptif-solutions for reporting and testing the fix.
+
 ## 1.0.4
 ### Bug Fixes
 - Fixed timezone handling issue by updating the `timezone` dependency to version `0.10.1`, ensuring better compatibility and functionality across different platforms.

--- a/android/src/main/kotlin/com/ahmtydn/calendar_bridge/EventManager.kt
+++ b/android/src/main/kotlin/com/ahmtydn/calendar_bridge/EventManager.kt
@@ -7,15 +7,9 @@ import android.database.Cursor
 import android.provider.CalendarContract
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.text.SimpleDateFormat
 import java.util.*
-import android.util.Log
 
 class EventManager(private val context: Context) {
-
-    companion object {
-        private const val TAG = "EventManager"
-    }
 
     suspend fun retrieveEvents(calendarId: String, arguments: Map<String, Any>): List<Map<String, Any>> = withContext(Dispatchers.IO) {
         val events = mutableListOf<Map<String, Any>>()
@@ -43,12 +37,10 @@ class EventManager(private val context: Context) {
         var selectionArgs: Array<String>
 
         if (eventIds != null && eventIds.isNotEmpty()) {
-            // Query specific events by ID
             val placeholders = eventIds.joinToString(",") { "?" }
             selection = "${CalendarContract.Instances.EVENT_ID} IN ($placeholders)"
             selectionArgs = eventIds.toTypedArray()
         } else {
-            // Query by calendar and date range using Instances
             val selectionParts = mutableListOf("${CalendarContract.Events.CALENDAR_ID} = ?")
             val argsList = mutableListOf(calendarId)
 
@@ -65,7 +57,6 @@ class EventManager(private val context: Context) {
             selection = selectionParts.joinToString(" AND ")
             selectionArgs = argsList.toTypedArray()
         }
-
 
         val instancesUri = CalendarContract.Instances.CONTENT_URI.buildUpon().apply {
             ContentUris.appendId(this, startDate ?: 0L)
@@ -108,19 +99,19 @@ class EventManager(private val context: Context) {
 
                 description?.let { eventMap["description"] = it }
                 location?.let { eventMap["location"] = it }
-                rrule?.let { eventMap["recurrenceRule"] = it }
+                rrule?.let { 
+                    eventMap["recurrenceRule"] = "RRULE:$it"
+                }
   
                 if (rrule != null) {
                     eventMap["originalStart"] = originalStartTime
                 }
 
-                // Get attendees
                 val attendees = getEventAttendees(eventId)
                 if (attendees.isNotEmpty()) {
                     eventMap["attendees"] = attendees
                 }
 
-                // Get reminders
                 val reminders = getEventReminders(eventId)
                 if (reminders.isNotEmpty()) {
                     eventMap["reminders"] = reminders
@@ -176,8 +167,11 @@ class EventManager(private val context: Context) {
             
             arguments["recurrenceRule"]?.let {
                 val raw = it as String
-                val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) raw.substring(6).trim() else raw.trim()
-                Log.d(TAG, "Normalized recurrence rule to: $normalized")
+                val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) {
+                    raw.substring(6).trim()
+                } else {
+                    raw.trim()
+                }
                 put(CalendarContract.Events.RRULE, normalized)
             }
         }
@@ -188,12 +182,10 @@ class EventManager(private val context: Context) {
         val eventId = uri.lastPathSegment
             ?: throw CalendarException.PlatformError("Failed to get event ID")
 
-        // Add attendees if provided
         arguments["attendees"]?.let { attendees ->
             addEventAttendees(eventId, attendees as List<Map<String, Any>>)
         }
 
-        // Add reminders if provided
         arguments["reminders"]?.let { reminders ->
             addEventReminders(eventId, reminders as List<Map<String, Any>>)
         }
@@ -205,7 +197,6 @@ class EventManager(private val context: Context) {
         val eventId = arguments["eventId"] as? String
             ?: throw CalendarException.InvalidArgument("Event ID is required")
 
-        // Check if event exists
         val cursor = context.contentResolver.query(
             CalendarContract.Events.CONTENT_URI,
             arrayOf(CalendarContract.Events._ID),
@@ -256,8 +247,11 @@ class EventManager(private val context: Context) {
         
         arguments["recurrenceRule"]?.let {
             val raw = it as String
-            val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) raw.substring(6).trim() else raw.trim()
-            Log.d(TAG, "Normalized recurrence rule to: $normalized")
+            val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) {
+                raw.substring(6).trim()
+            } else {
+                raw.trim()
+            }
             values.put(CalendarContract.Events.RRULE, normalized)
         }
 
@@ -272,27 +266,21 @@ class EventManager(private val context: Context) {
             throw CalendarException.PlatformError("Failed to update event")
         }
 
-        // Update attendees if provided
         arguments["attendees"]?.let { attendees ->
-            // Delete existing attendees
             context.contentResolver.delete(
                 CalendarContract.Attendees.CONTENT_URI,
                 "${CalendarContract.Attendees.EVENT_ID} = ?",
                 arrayOf(eventId)
             )
-            // Add new attendees
             addEventAttendees(eventId, attendees as List<Map<String, Any>>)
         }
 
-        // Update reminders if provided
         arguments["reminders"]?.let { reminders ->
-            // Delete existing reminders
             context.contentResolver.delete(
                 CalendarContract.Reminders.CONTENT_URI,
                 "${CalendarContract.Reminders.EVENT_ID} = ?",
                 arrayOf(eventId)
             )
-            // Add new reminders
             addEventReminders(eventId, reminders as List<Map<String, Any>>)
         }
 
@@ -300,7 +288,6 @@ class EventManager(private val context: Context) {
     }
 
     suspend fun deleteEvent(calendarId: String, eventId: String): Boolean = withContext(Dispatchers.IO) {
-        // Verify event exists in the specified calendar
         val cursor = context.contentResolver.query(
             CalendarContract.Events.CONTENT_URI,
             arrayOf(CalendarContract.Events._ID, CalendarContract.Events.CALENDAR_ID),
@@ -325,7 +312,6 @@ class EventManager(private val context: Context) {
     }
 
     suspend fun deleteEventInstance(calendarId: String, eventId: String, startDate: Long, followingInstances: Boolean): Boolean = withContext(Dispatchers.IO) {
-        // Verify event exists in the specified calendar
         val cursor = context.contentResolver.query(
             CalendarContract.Events.CONTENT_URI,
             arrayOf(CalendarContract.Events._ID, CalendarContract.Events.CALENDAR_ID, CalendarContract.Events.RRULE),
@@ -343,7 +329,6 @@ class EventManager(private val context: Context) {
             isRecurring = !rrule.isNullOrEmpty()
         } ?: throw CalendarException.EventNotFound(eventId)
 
-        // For recurring events, create an exception instead of deleting
         if (isRecurring) {
             val exceptionValues = ContentValues().apply {
                 put(CalendarContract.Events.ORIGINAL_ID, eventId)
@@ -352,8 +337,6 @@ class EventManager(private val context: Context) {
                 put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CANCELED)
                 
                 if (followingInstances) {
-                    // For future events, we need to modify the original event's RRULE
-                    // This is a simplified implementation - in practice, you'd need to update the RRULE
                     put(CalendarContract.Events.DTSTART, startDate)
                 }
             }
@@ -361,7 +344,6 @@ class EventManager(private val context: Context) {
             val uri = context.contentResolver.insert(CalendarContract.Events.CONTENT_URI, exceptionValues)
             return@withContext uri != null
         } else {
-            // For non-recurring events, just delete normally
             return@withContext deleteEvent(calendarId, eventId)
         }
     }

--- a/android/src/main/kotlin/com/ahmtydn/calendar_bridge/EventManager.kt
+++ b/android/src/main/kotlin/com/ahmtydn/calendar_bridge/EventManager.kt
@@ -9,8 +9,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.*
+import android.util.Log
 
 class EventManager(private val context: Context) {
+
+    companion object {
+        private const val TAG = "EventManager"
+    }
 
     suspend fun retrieveEvents(calendarId: String, arguments: Map<String, Any>): List<Map<String, Any>> = withContext(Dispatchers.IO) {
         val events = mutableListOf<Map<String, Any>>()
@@ -169,8 +174,11 @@ class EventManager(private val context: Context) {
                 put(CalendarContract.Events.STATUS, statusFromString(it as String))
             }
             
-            arguments["recurrenceRule"]?.let { 
-                put(CalendarContract.Events.RRULE, it as String)
+            arguments["recurrenceRule"]?.let {
+                val raw = it as String
+                val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) raw.substring(6).trim() else raw.trim()
+                Log.d(TAG, "Normalized recurrence rule to: $normalized")
+                put(CalendarContract.Events.RRULE, normalized)
             }
         }
 
@@ -246,8 +254,11 @@ class EventManager(private val context: Context) {
             values.put(CalendarContract.Events.STATUS, statusFromString(it as String))
         }
         
-        arguments["recurrenceRule"]?.let { 
-            values.put(CalendarContract.Events.RRULE, it as String)
+        arguments["recurrenceRule"]?.let {
+            val raw = it as String
+            val normalized = if (raw.startsWith("RRULE:", ignoreCase = true)) raw.substring(6).trim() else raw.trim()
+            Log.d(TAG, "Normalized recurrence rule to: $normalized")
+            values.put(CalendarContract.Events.RRULE, normalized)
         }
 
         val updatedRows = context.contentResolver.update(

--- a/darwin/Classes/EventManager.swift
+++ b/darwin/Classes/EventManager.swift
@@ -28,14 +28,12 @@ class EventManager {
         var events: [EKEvent] = []
         
         if let eventIds = eventIds {
-            // Retrieve specific events by ID
             for eventId in eventIds {
                 if let event = eventStore.event(withIdentifier: eventId) {
                     events.append(event)
                 }
             }
         } else {
-            // Retrieve events by date range
             let predicate = eventStore.predicateForEvents(
                 withStart: startDate ?? Date.distantPast,
                 end: endDate ?? Date.distantFuture,
@@ -172,12 +170,10 @@ class EventManager {
             event.endDate = endDate
         }
         
-        // Handle attendees
         if let attendeesData = dict["attendees"] as? [[String: Any]] {
             setAttendees(attendeesData, event)
         }
         
-        // Handle reminders
         if let remindersData = dict["reminders"] as? [[String: Any]] {
             let alarms = remindersData.compactMap { reminderDict -> EKAlarm? in
                 guard let minutes = reminderDict["minutes"] as? Int else { return nil }
@@ -186,7 +182,6 @@ class EventManager {
             event.alarms = alarms
         }
         
-        // Handle availability
         if let availabilityString = dict["availability"] as? String {
             switch availabilityString {
             case "busy":
@@ -206,8 +201,14 @@ class EventManager {
             }
         }
         
-        // Handle recurrence rule
-        if let recurrenceDict = dict["recurrenceRule"] as? [String: Any] {
+        // Handle recurrence rule - accept both string and dictionary formats
+        if let recurrenceString = dict["recurrenceRule"] as? String {
+            // String format from rrule package: "RRULE:FREQ=DAILY;COUNT=10"
+            if let rules = parseRRULEString(recurrenceString) {
+                event.recurrenceRules = rules
+            }
+        } else if let recurrenceDict = dict["recurrenceRule"] as? [String: Any] {
+            // Dictionary format (legacy support)
             event.recurrenceRules = createEKRecurrenceRules(recurrenceDict)
         }
     }
@@ -235,14 +236,13 @@ class EventManager {
         dict["start"] = Int(event.startDate.timeIntervalSince1970 * 1000)
         dict["end"] = Int(event.endDate.timeIntervalSince1970 * 1000)
         
-        // Handle attendees
         if let attendees = event.attendees {
             let attendeesData = attendees.map { attendee in
                 #if os(iOS)
                 var email = ""
                 let url = attendee.url
                 if url.scheme == "mailto" {
-                    email = String(url.absoluteString.dropFirst(7)) 
+                    email = String(url.absoluteString.dropFirst(7))
                 } else {
                     email = url.absoluteString
                 }
@@ -259,7 +259,6 @@ class EventManager {
             dict["attendees"] = attendeesData
         }
         
-        // Handle reminders
         if let alarms = event.alarms {
             let remindersData = alarms.compactMap { alarm -> [String: Any]? in
                 #if os(iOS)
@@ -272,11 +271,15 @@ class EventManager {
             dict["reminders"] = remindersData
         }
         
-        // Handle availability
         dict["availability"] = availabilityToString(event.availability)
-        
-        // Handle status
         dict["status"] = statusToString(event.status)
+        
+        // Convert recurrence rules to RRULE string format
+        if let recurrenceRules = event.recurrenceRules, !recurrenceRules.isEmpty {
+            if let rruleString = convertRecurrenceRulesToString(recurrenceRules) {
+                dict["recurrenceRule"] = rruleString
+            }
+        }
         
         var originalStartDate: Int64? = nil
         
@@ -391,6 +394,211 @@ class EventManager {
     
     // MARK: - Recurrence Rule Handling
     
+    private func parseRRULEString(_ rruleString: String) -> [EKRecurrenceRule]? {
+        // Remove "RRULE:" prefix if present
+        var ruleString = rruleString
+        if ruleString.hasPrefix("RRULE:") {
+            ruleString = String(ruleString.dropFirst(6))
+        }
+        
+        // Parse the RRULE string into components
+        var components: [String: String] = [:]
+        let parts = ruleString.split(separator: ";")
+        
+        for part in parts {
+            let keyValue = part.split(separator: "=", maxSplits: 1)
+            if keyValue.count == 2 {
+                components[String(keyValue[0])] = String(keyValue[1])
+            }
+        }
+        
+        // Extract frequency (required)
+        guard let freqString = components["FREQ"] else {
+            return nil
+        }
+        
+        var ekFrequency: EKRecurrenceFrequency
+        switch freqString.uppercased() {
+        case "DAILY":
+            ekFrequency = .daily
+        case "WEEKLY":
+            ekFrequency = .weekly
+        case "MONTHLY":
+            ekFrequency = .monthly
+        case "YEARLY":
+            ekFrequency = .yearly
+        default:
+            return nil
+        }
+        
+        // Extract interval (optional, default 1)
+        let interval = components["INTERVAL"].flatMap { Int($0) } ?? 1
+        
+        // Extract end condition
+        var recurrenceEnd: EKRecurrenceEnd?
+        if let countString = components["COUNT"], let count = Int(countString), count > 0 {
+            recurrenceEnd = EKRecurrenceEnd(occurrenceCount: count)
+        } else if let untilString = components["UNTIL"] {
+            if let endDate = parseUntilDate(untilString) {
+                recurrenceEnd = EKRecurrenceEnd(end: endDate)
+            }
+        }
+        
+        // Parse BYDAY
+        var daysOfWeek: [EKRecurrenceDayOfWeek]?
+        if let byDayString = components["BYDAY"] {
+            let dayStrings = byDayString.split(separator: ",").map { String($0) }
+            daysOfWeek = dayStrings.compactMap { recurrenceDayOfWeekFromString($0) }
+        }
+        
+        // Parse BYMONTHDAY
+        var daysOfMonth: [NSNumber]?
+        if let byMonthDayString = components["BYMONTHDAY"] {
+            let days = byMonthDayString.split(separator: ",").compactMap { Int($0) }
+            daysOfMonth = days.map { NSNumber(value: $0) }
+        }
+        
+        // Parse BYMONTH
+        var monthsOfYear: [NSNumber]?
+        if let byMonthString = components["BYMONTH"] {
+            let months = byMonthString.split(separator: ",").compactMap { Int($0) }
+            monthsOfYear = months.map { NSNumber(value: $0) }
+        }
+        
+        // Parse BYYEARDAY
+        var daysOfYear: [NSNumber]?
+        if let byYearDayString = components["BYYEARDAY"] {
+            let days = byYearDayString.split(separator: ",").compactMap { Int($0) }
+            daysOfYear = days.map { NSNumber(value: $0) }
+        }
+        
+        // Parse BYWEEKNO
+        var weeksOfYear: [NSNumber]?
+        if let byWeekNoString = components["BYWEEKNO"] {
+            let weeks = byWeekNoString.split(separator: ",").compactMap { Int($0) }
+            weeksOfYear = weeks.map { NSNumber(value: $0) }
+        }
+        
+        // Parse BYSETPOS
+        var setPositions: [NSNumber]?
+        if let bySetPosString = components["BYSETPOS"] {
+            let positions = bySetPosString.split(separator: ",").compactMap { Int($0) }
+            setPositions = positions.map { NSNumber(value: $0) }
+        }
+        
+        let rule = EKRecurrenceRule(
+            recurrenceWith: ekFrequency,
+            interval: interval,
+            daysOfTheWeek: daysOfWeek,
+            daysOfTheMonth: daysOfMonth,
+            monthsOfTheYear: monthsOfYear,
+            weeksOfTheYear: weeksOfYear,
+            daysOfTheYear: daysOfYear,
+            setPositions: setPositions,
+            end: recurrenceEnd
+        )
+        
+        return [rule]
+    }
+    
+    private func convertRecurrenceRulesToString(_ rules: [EKRecurrenceRule]) -> String? {
+        guard let rule = rules.first else { return nil }
+        
+        var components: [String] = []
+        
+        // Add frequency
+        let freqString: String
+        switch rule.frequency {
+        case .daily:
+            freqString = "DAILY"
+        case .weekly:
+            freqString = "WEEKLY"
+        case .monthly:
+            freqString = "MONTHLY"
+        case .yearly:
+            freqString = "YEARLY"
+        @unknown default:
+            freqString = "DAILY"
+        }
+        components.append("FREQ=\(freqString)")
+        
+        // Add interval if not 1
+        if rule.interval > 1 {
+            components.append("INTERVAL=\(rule.interval)")
+        }
+        
+        // Add count or until
+        if let recurrenceEnd = rule.recurrenceEnd {
+            if recurrenceEnd.occurrenceCount > 0 {
+                components.append("COUNT=\(recurrenceEnd.occurrenceCount)")
+            } else if let endDate = recurrenceEnd.endDate {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime]
+                let dateString = formatter.string(from: endDate)
+                components.append("UNTIL=\(dateString)")
+            }
+        }
+        
+        // Add BYDAY
+        if let daysOfWeek = rule.daysOfTheWeek, !daysOfWeek.isEmpty {
+            let dayStrings = daysOfWeek.map { day -> String in
+                let prefix = day.weekNumber != 0 ? "\(day.weekNumber)" : ""
+                let dayCode: String
+                switch day.dayOfTheWeek {
+                case .sunday: dayCode = "SU"
+                case .monday: dayCode = "MO"
+                case .tuesday: dayCode = "TU"
+                case .wednesday: dayCode = "WE"
+                case .thursday: dayCode = "TH"
+                case .friday: dayCode = "FR"
+                case .saturday: dayCode = "SA"
+                @unknown default: dayCode = "MO"
+                }
+                return "\(prefix)\(dayCode)"
+            }
+            components.append("BYDAY=\(dayStrings.joined(separator: ","))")
+        }
+        
+        // Add BYMONTHDAY
+        if let daysOfMonth = rule.daysOfTheMonth, !daysOfMonth.isEmpty {
+            let dayStrings = daysOfMonth.map { "\($0.intValue)" }
+            components.append("BYMONTHDAY=\(dayStrings.joined(separator: ","))")
+        }
+        
+        // Add BYMONTH
+        if let monthsOfYear = rule.monthsOfTheYear, !monthsOfYear.isEmpty {
+            let monthStrings = monthsOfYear.map { "\($0.intValue)" }
+            components.append("BYMONTH=\(monthStrings.joined(separator: ","))")
+        }
+        
+        // Add BYYEARDAY
+        if let daysOfYear = rule.daysOfTheYear, !daysOfYear.isEmpty {
+            let dayStrings = daysOfYear.map { "\($0.intValue)" }
+            components.append("BYYEARDAY=\(dayStrings.joined(separator: ","))")
+        }
+        
+        // Add BYWEEKNO
+        if let weeksOfYear = rule.weeksOfTheYear, !weeksOfYear.isEmpty {
+            let weekStrings = weeksOfYear.map { "\($0.intValue)" }
+            components.append("BYWEEKNO=\(weekStrings.joined(separator: ","))")
+        }
+        
+        // Add BYSETPOS
+        if let setPositions = rule.setPositions, !setPositions.isEmpty {
+            let posStrings = setPositions.map { "\($0.intValue)" }
+            components.append("BYSETPOS=\(posStrings.joined(separator: ","))")
+        }
+        
+        // Return with RRULE: prefix for consistency with rrule package
+        return "RRULE:" + components.joined(separator: ";")
+    }
+    
+    private func parseUntilDate(_ dateString: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: dateString)
+    }
+    
     private func createEKRecurrenceRules(_ recurrenceDict: [String: Any]) -> [EKRecurrenceRule]? {
         guard let frequency = recurrenceDict["freq"] as? String else { return nil }
         
@@ -423,37 +631,31 @@ class EventManager {
             }
         }
         
-        // Parse BYDAY values
         var daysOfWeek: [EKRecurrenceDayOfWeek]?
         if let byDayStrings = recurrenceDict["byday"] as? [String] {
             daysOfWeek = byDayStrings.compactMap { recurrenceDayOfWeekFromString($0) }
         }
         
-        // Parse BYMONTHDAY values
         var daysOfMonth: [NSNumber]?
         if let byMonthDays = recurrenceDict["bymonthday"] as? [Int] {
             daysOfMonth = byMonthDays.map { NSNumber(value: $0) }
         }
         
-        // Parse BYMONTH values
         var monthsOfYear: [NSNumber]?
         if let byMonths = recurrenceDict["bymonth"] as? [Int] {
             monthsOfYear = byMonths.map { NSNumber(value: $0) }
         }
         
-        // Parse BYYEARDAY values
         var daysOfYear: [NSNumber]?
         if let byYearDays = recurrenceDict["byyearday"] as? [Int] {
             daysOfYear = byYearDays.map { NSNumber(value: $0) }
         }
         
-        // Parse BYWEEKNO values
         var weeksOfYear: [NSNumber]?
         if let byWeeks = recurrenceDict["byweekno"] as? [Int] {
             weeksOfYear = byWeeks.map { NSNumber(value: $0) }
         }
         
-        // Parse BYSETPOS values
         var setPositions: [NSNumber]?
         if let bySetPos = recurrenceDict["bysetpos"] as? [Int] {
             setPositions = bySetPos.map { NSNumber(value: $0) }
@@ -475,7 +677,6 @@ class EventManager {
     }
     
     private func recurrenceDayOfWeekFromString(_ dayString: String) -> EKRecurrenceDayOfWeek? {
-        // Parse strings like "MO", "TU", "1MO", "-1SU" etc.
         let pattern = "^(?:(\\+|-)?([0-9]{1,2}))?([A-Z]{2})$"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
               let match = regex.firstMatch(in: dayString, range: NSRange(dayString.startIndex..., in: dayString)) else {
@@ -485,12 +686,10 @@ class EventManager {
         var weekNumber: Int = 0
         var dayOfWeek: EKWeekday
         
-        // Extract week number if present
         if match.range(at: 2).location != NSNotFound {
             let weekNumberString = String(dayString[Range(match.range(at: 2), in: dayString)!])
             weekNumber = Int(weekNumberString) ?? 0
             
-            // Check for minus sign
             if match.range(at: 1).location != NSNotFound {
                 let signString = String(dayString[Range(match.range(at: 1), in: dayString)!])
                 if signString == "-" {
@@ -499,7 +698,6 @@ class EventManager {
             }
         }
         
-        // Extract day of week
         let dayString = String(dayString[Range(match.range(at: 3), in: dayString)!])
         switch dayString {
         case "SU": dayOfWeek = .sunday
@@ -529,7 +727,6 @@ class EventManager {
             let name = attendeeDict["name"] as? String ?? ""
             let role = attendeeDict["role"] as? Int ?? EKParticipantRole.required.rawValue
             
-            // Check if attendee already exists
             if let existingAttendees = event.attendees {
                 if let existingAttendee = existingAttendees.first(where: { participant in
                     return extractEmailFromParticipant(participant) == email
@@ -539,18 +736,15 @@ class EventManager {
                 }
             }
             
-            // Create new participant
             if let participant = createParticipant(name: name, emailAddress: email, role: role) {
                 attendees.append(participant)
             }
         }
         
-        // Use KVC to set attendees (this is a workaround since attendees is normally read-only)
         event.setValue(attendees, forKey: "attendees")
     }
     
     private func createParticipant(name: String, emailAddress: String, role: Int) -> EKParticipant? {
-        // This uses a private API approach similar to the reference implementation
         guard let ekAttendeeClass = NSClassFromString("EKAttendee") as? NSObject.Type else {
             return nil
         }
@@ -573,7 +767,6 @@ class EventManager {
             return url.absoluteString
         }
         #elseif os(macOS)
-        // For macOS, try to get email from the URL or use reflection to access emailAddress
         if let emailAddress = participant.value(forKey: "emailAddress") as? String {
             return emailAddress
         }

--- a/darwin/calendar_bridge.podspec
+++ b/darwin/calendar_bridge.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'calendar_bridge'
-  s.version          = '1.0.0'
+  s.version          = '1.0.5'
   s.summary          = 'A cross-platform Flutter plugin for accessing and managing device calendars.'
   s.description      = <<-DESC
 A cross-platform Flutter plugin for accessing and managing device calendars on Android, iOS, and macOS with clean architecture.

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,28 +1,8 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+analyzer: 
+  errors: 
+    todo: ignore
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:

--- a/example/lib/features/calendar/presentation/screens/calendar_list_screen.dart
+++ b/example/lib/features/calendar/presentation/screens/calendar_list_screen.dart
@@ -21,7 +21,7 @@ class CalendarListScreen extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: () {
-              // TODO: Navigate to create calendar screen
+              // TODO(ahmtydn): Navigate to create calendar screen
               _showCreateCalendarDialog(context, ref);
             },
           ),

--- a/example/lib/features/calendar/presentation/screens/settings_screen.dart
+++ b/example/lib/features/calendar/presentation/screens/settings_screen.dart
@@ -1,6 +1,8 @@
+import 'package:calendar_bridge/calendar_bridge.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:timezone/timezone.dart';
 
 import '../../../../core/providers/calendar_providers.dart';
 import '../../../../core/theme/theme.dart';
@@ -171,6 +173,12 @@ class SettingsScreen extends ConsumerWidget {
                     subtitle: const Text('Reload calendars and events'),
                     onTap: () => _refreshAllData(context, ref),
                   ),
+                  ListTile(
+                    leading: const Icon(Icons.repeat),
+                    title: const Text('Create Recurring Test Event'),
+                    subtitle: const Text('Creates a daily RRULE (count=10)'),
+                    onTap: () => _createRecurringTestEvent(context, ref),
+                  ),
                 ],
               ),
             ],
@@ -178,6 +186,47 @@ class SettingsScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _createRecurringTestEvent(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    try {
+      final api = ref.read(calendarBridgeProvider);
+      final defaultCalendar = await api.getDefaultCalendar();
+
+      final start = TZDateTime.now(UTC).add(const Duration(hours: 1));
+      final end = start.add(const Duration(hours: 1));
+
+      final recurrence = RecurrenceRule(frequency: Frequency.daily, count: 10);
+
+      final event = CalendarEvent(
+        calendarId: defaultCalendar.id,
+        title: 'RRULE test',
+        start: start,
+        end: end,
+        recurrenceRule: recurrence,
+      );
+
+      await api.createEvent(event);
+      ref.invalidate(eventsProvider);
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Recurring event created')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to create recurring event: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 
   Widget _buildSection(

--- a/example/lib/features/calendar/presentation/screens/settings_screen.dart
+++ b/example/lib/features/calendar/presentation/screens/settings_screen.dart
@@ -265,7 +265,7 @@ class SettingsScreen extends ConsumerWidget {
                       title: Text(calendar.name),
                       subtitle: Text(calendar.accountName ?? 'Local Calendar'),
                       onTap: () {
-                        // TODO: Implement setting default calendar
+                        // TODO(ahmtydn): Implement setting default calendar
                         Navigator.of(context).pop();
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.4"
   characters:
     dependency: transitive
     description:
@@ -142,6 +142,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -207,10 +223,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -348,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:
@@ -364,10 +380,10 @@ packages:
     dependency: "direct main"
     description:
       name: timezone
-      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,20 +1,12 @@
 name: calendar_bridge_example
 description: "Demonstrates how to use the calendar_bridge plugin."
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
 version: 1.0.0+1
 
 environment:
   sdk: ^3.9.2
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
@@ -22,11 +14,6 @@ dependencies:
     sdk: flutter
 
   calendar_bridge:
-    # When depending on this package from a real application you should use:
-    #   calendar_bridge: ^x.y.z
-    # See https://dart.dev/tools/pub/dependencies#version-constraints
-    # The example app is bundled with the plugin so we use a path dependency on
-    # the parent directory to use the current plugin's version.
     path: ../
 
   # UI and state management
@@ -52,52 +39,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package

--- a/lib/src/domain/models/event.dart
+++ b/lib/src/domain/models/event.dart
@@ -46,7 +46,8 @@ class CalendarEvent {
       location: json['location'] as String?,
       url: json['url'] as String?,
       recurrenceRule: json['recurrenceRule'] != null
-          ? RecurrenceRule.fromString(json['recurrenceRule'] as String)
+          ? RecurrenceRule.fromString(
+              _normalizeRRule(json['recurrenceRule'] as String))
           : null,
       originalStart: json['originalStart'] != null
           ? TZDateTime.fromMillisecondsSinceEpoch(
@@ -73,6 +74,13 @@ class CalendarEvent {
           : null,
       eventColor: json['eventColor'] as String?,
     );
+  }
+
+  static String _normalizeRRule(String rrule) {
+    if (!rrule.startsWith('RRULE:')) {
+      return 'RRULE:$rrule';
+    }
+    return rrule;
   }
 
   /// Create a new event with required fields

--- a/lib/src/domain/models/event.dart
+++ b/lib/src/domain/models/event.dart
@@ -29,6 +29,34 @@ class CalendarEvent {
     this.eventColor,
   });
 
+  /// Create a new event with required fields
+  factory CalendarEvent.create({
+    required String calendarId,
+    required String title,
+    required TZDateTime start,
+    required TZDateTime end,
+  }) =>
+      CalendarEvent(
+        calendarId: calendarId,
+        title: title,
+        start: start,
+        end: end,
+      );
+
+  /// Create an all-day event
+  factory CalendarEvent.allDay({
+    required String calendarId,
+    required String title,
+    required TZDateTime date,
+  }) =>
+      CalendarEvent(
+        calendarId: calendarId,
+        title: title,
+        start: date,
+        end: date.add(const Duration(days: 1)),
+        allDay: true,
+      );
+
   /// Creates a calendar event from a JSON map
   factory CalendarEvent.fromJson(Map<String, dynamic> json) {
     return CalendarEvent(
@@ -47,7 +75,8 @@ class CalendarEvent {
       url: json['url'] as String?,
       recurrenceRule: json['recurrenceRule'] != null
           ? RecurrenceRule.fromString(
-              _normalizeRRule(json['recurrenceRule'] as String))
+              _normalizeRRule(json['recurrenceRule'] as String),
+            )
           : null,
       originalStart: json['originalStart'] != null
           ? TZDateTime.fromMillisecondsSinceEpoch(
@@ -82,34 +111,6 @@ class CalendarEvent {
     }
     return rrule;
   }
-
-  /// Create a new event with required fields
-  factory CalendarEvent.create({
-    required String calendarId,
-    required String title,
-    required TZDateTime start,
-    required TZDateTime end,
-  }) =>
-      CalendarEvent(
-        calendarId: calendarId,
-        title: title,
-        start: start,
-        end: end,
-      );
-
-  /// Create an all-day event
-  factory CalendarEvent.allDay({
-    required String calendarId,
-    required String title,
-    required TZDateTime date,
-  }) =>
-      CalendarEvent(
-        calendarId: calendarId,
-        title: title,
-        start: date,
-        end: date.add(const Duration(days: 1)),
-        allDay: true,
-      );
 
   /// ID of the calendar this event belongs to
   final String calendarId;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: calendar_bridge
 description: A cross-platform Flutter plugin for accessing and managing device calendars on Android, iOS, and macOS with clean architecture.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/ahmtydn/calendar_bridge
 
 topics:


### PR DESCRIPTION
Root cause:
The Dart rrule package outputs rules as "RRULE:FREQ=..." while Android's Events.RRULE expects just the rule content (e.g. "FREQ=WEEKLY;..."). The plugin normalized reads but wrote the full "RRULE:" string on create/update which Android rejected ("Invalid recurrence rule").

Fix:
Strip a leading "RRULE:" (case-insensitive) and trim before writing to `CalendarContract.Events.RRULE` in:
- `android/src/main/kotlin/com/ahmtydn/calendar_bridge/EventManager.kt`

This change normalizes the write path; a small debug log was added to help verification.

Test checklist:
- Create an event from Dart using a recurrence rule string produced by Dart's rrule (which includes "RRULE:").
- Confirm Android log shows `Normalized recurrence rule to: ...`.
- Confirm the event creates/updates successfully without `Invalid recurrence rule` and appears correctly in Google Calendar.

Notes:
Read-side normalization (prepending `RRULE:` when returning events to Dart) is already present; this completes the round-trip behavior.
